### PR TITLE
Summary:  add Semigroup instance (GHC 8.4 compat)

### DIFF
--- a/src/Test/Hspec.hs
+++ b/src/Test/Hspec.hs
@@ -30,6 +30,9 @@ module Test.Hspec (
 import           Control.Applicative
 import           Data.Monoid
 #endif
+#if MIN_VERSION_base(4,9,0)
+import           Data.Semigroup
+#endif
 
 import           Control.Monad
 import           Data.List (intercalate)
@@ -75,9 +78,18 @@ it label = add . SpecExample label . evaluateExpectation
 -- | Summary of a test run.
 data Summary = Summary Int Int
 
+#if MIN_VERSION_base(4,9,0)
+instance Semigroup Summary where
+  (Summary x1 x2) <> (Summary y1 y2) = Summary (x1 + y1) (x2 + y2)
+#endif  
+
 instance Monoid Summary where
   mempty = Summary 0 0
+#if MIN_VERSION_base(4,9,0)
+  mappend = (<>)
+#else
   (Summary x1 x2) `mappend` (Summary y1 y2) = Summary (x1 + y1) (x2 + y2)
+#endif
 
 runSpec :: Spec -> IO Summary
 runSpec = runForrest []


### PR DESCRIPTION
This fixes #4, and enables build with GHC 8.4.1.  Also tested on 8.0.2 and 7.10.3.